### PR TITLE
fix: Skip NPM_TOKEN verification if it's not defined

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -3,7 +3,13 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    '@semantic-release/npm',
+    [
+      '@semantic-release/npm',
+      // Skip token verification if NPM_TOKEN isn't defined
+      // This is because dependabot PRs do not have access to this token, but don't need it
+      // In actual releases, the token will be verified.
+      { verifyConditions: process.env.NPM_TOKEN ? '@semantic-release/npm' : false },
+    ],
     '@semantic-release/github',
     '@semantic-release/git',
   ],


### PR DESCRIPTION
This allows dependabot PRs to not cause failing releases, as they do not have access to the NPM_TOKEN secret. This is OK, as the 'chore' commit messages they generate never directly cause a release