### PR TITLE
chore: Remove non-functional release configuration

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -3,13 +3,7 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    [
-      '@semantic-release/npm',
-      // Skip token verification if NPM_TOKEN isn't defined
-      // This is because dependabot PRs do not have access to this token, but don't need it
-      // In actual releases, the token will be verified.
-      { verifyConditions: process.env.NPM_TOKEN ? '@semantic-release/npm' : false },
-    ],
+    '@semantic-release/npm',
     '@semantic-release/github',
     '@semantic-release/git',
   ],


### PR DESCRIPTION
We're going to change the default branch to develop so that dependabot PRs don't trigger a semantic release run