### PR TITLE
fix: Add a class to the second code block

### DIFF
--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -15,7 +15,7 @@ export const TOP_AND_TAIL = (data) => `${PRE_CODE}${data}${POST_CODE}`;
 export const TOP_AND_TAIL_SVG = (data: string, svg: string) => {
   const lineCount = (data.match(/\n/g) || []).length + 1;
   const preSvg =
-    '<code style="z-index:1; visibility: hidden; grid-area: container;">'
+    '<code class="language-annotated-hexdump-overlay" style="z-index:1; visibility: hidden; grid-area: container;">'
     + `<svg style="opacity: 0.3; visibility: visible; width: 100%; height: ${
       (1.2 * lineCount).toFixed(1)
     }em;" xmlns="http://www.w3.oprg/2000/svg">`;

--- a/src/common.ts
+++ b/src/common.ts
@@ -355,7 +355,7 @@ export function processTokens(tokens: BaseToken[]): string {
     // The SVG gets wrapped in an invisible code element so that it
     // inherits the correct fonts
     return (
-      '<code style="z-index:1; visibility: hidden; grid-area: container;">'
+      '<code class="language-annotated-hexdump-overlay" style="z-index:1; visibility: hidden; grid-area: container;">'
       + `<svg style="opacity: 0.3; visibility: visible; width: 100%; height: ${svgHeight}em;" xmlns="http://www.w3.oprg/2000/svg">`
       + highlightRects.join('')
       + '</svg></code>'


### PR DESCRIPTION
This resolves issues with downstream plugins for highlight-js which may expect to find a class on the code block.
Looking at you, markdown-it-highlightjs

Resolves #71 